### PR TITLE
test: validate /digger commands functionality

### DIFF
--- a/.github/workflows/iac.yml
+++ b/.github/workflows/iac.yml
@@ -113,8 +113,8 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
-          # For issue comments, checkout the PR head commit
-          ref: ${{ github.event_name == 'issue_comment' && github.event.pull_request.head.sha || github.sha }}
+          # For issue comments, we'll get the proper SHA in the next step
+          ref: ${{ github.event_name == 'issue_comment' && github.sha || github.sha }}
 
       - name: Get PR context for issue comments
         id: pr-context
@@ -135,6 +135,12 @@ jobs:
           echo "head_ref=${PR_HEAD_REF}" >> $GITHUB_OUTPUT
           
           echo "🔍 PR Context: #${PR_NUMBER}, SHA: ${PR_HEAD_SHA}, Ref: ${PR_HEAD_REF}"
+
+      - name: Checkout PR head for issue comments
+        if: github.event_name == 'issue_comment'
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ steps.pr-context.outputs.head_sha }}
 
       - name: Create pending status check
         if: github.event_name == 'issue_comment'

--- a/.github/workflows/iac.yml
+++ b/.github/workflows/iac.yml
@@ -96,6 +96,7 @@ jobs:
           echo "Affected environments: $ENVIRONMENTS"
 
   digger:
+    name: "Digger - ${{ matrix.environment }}"
     needs: detect-environments
     if: ${{ needs.detect-environments.outputs.environments != '[]' }}
     timeout-minutes: 60
@@ -111,6 +112,49 @@ jobs:
         environment: ${{ fromJSON(needs.detect-environments.outputs.environments) }}
     steps:
       - uses: actions/checkout@v4
+        with:
+          # For issue comments, checkout the PR head commit
+          ref: ${{ github.event_name == 'issue_comment' && github.event.pull_request.head.sha || github.sha }}
+
+      - name: Get PR context for issue comments
+        id: pr-context
+        if: github.event_name == 'issue_comment'
+        run: |
+          PR_NUMBER="${{ github.event.issue.number }}"
+          REPO="${{ github.repository }}"
+          
+          # Get PR details
+          PR_DATA=$(curl -s -H "authorization: Bearer ${{ secrets.GITHUB_TOKEN }}" \
+            "https://api.github.com/repos/${REPO}/pulls/${PR_NUMBER}")
+          
+          PR_HEAD_SHA=$(echo "$PR_DATA" | jq -r '.head.sha')
+          PR_HEAD_REF=$(echo "$PR_DATA" | jq -r '.head.ref')
+          
+          echo "pr_number=${PR_NUMBER}" >> $GITHUB_OUTPUT
+          echo "head_sha=${PR_HEAD_SHA}" >> $GITHUB_OUTPUT
+          echo "head_ref=${PR_HEAD_REF}" >> $GITHUB_OUTPUT
+          
+          echo "🔍 PR Context: #${PR_NUMBER}, SHA: ${PR_HEAD_SHA}, Ref: ${PR_HEAD_REF}"
+
+      - name: Create pending status check
+        if: github.event_name == 'issue_comment'
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const sha = '${{ steps.pr-context.outputs.head_sha }}' || '${{ github.sha }}';
+            const environment = '${{ matrix.environment }}';
+            const isApply = '${{ github.event.comment.body }}'.includes('/digger apply');
+            const action = isApply ? 'deploy' : 'plan';
+            
+            await github.rest.repos.createCommitStatus({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              sha: sha,
+              state: 'pending',
+              target_url: `https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}`,
+              description: `Running ${action} for ${environment} environment`,
+              context: `digger/${environment}/${action}`
+            });
 
       - name: Guard prod applies (prod is READ-ONLY)
         if: ${{ github.event_name == 'issue_comment' && contains(github.event.comment.body, '/digger apply') && matrix.environment == 'prod' }}
@@ -221,6 +265,32 @@ jobs:
             terragrunt run-all plan -no-color -parallelism 4
           fi
 
+      - name: Update status check on completion
+        if: always() && github.event_name == 'issue_comment'
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const sha = '${{ steps.pr-context.outputs.head_sha }}' || '${{ github.sha }}';
+            const environment = '${{ matrix.environment }}';
+            const isApply = '${{ github.event.comment.body }}'.includes('/digger apply');
+            const action = isApply ? 'deploy' : 'plan';
+            const jobStatus = '${{ job.status }}';
+            
+            const state = jobStatus === 'success' ? 'success' : 'failure';
+            const description = jobStatus === 'success' 
+              ? `Successfully ${action === 'deploy' ? 'deployed to' : 'planned'} ${environment} environment`
+              : `Failed to ${action} ${environment} environment`;
+            
+            await github.rest.repos.createCommitStatus({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              sha: sha,
+              state: state,
+              target_url: `https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}`,
+              description: description,
+              context: `digger/${environment}/${action}`
+            });
+
       - name: Deployment Status Notification
         if: always()
         run: |
@@ -239,6 +309,64 @@ jobs:
             echo "❌ Deployment failed for ${{ matrix.environment }} environment"
             echo "🔧 Check logs above for error details"
           fi
+
+      - name: Update deployment summary comment
+        if: always() && github.event_name == 'issue_comment'
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const prNumber = '${{ steps.pr-context.outputs.pr_number }}';
+            const environment = '${{ matrix.environment }}';
+            const isApply = '${{ github.event.comment.body }}'.includes('/digger apply');
+            const action = isApply ? 'deploy' : 'plan';
+            const jobStatus = '${{ job.status }}';
+            const runUrl = `https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}`;
+            
+            // Find existing deployment summary comment
+            const comments = await github.rest.issues.listComments({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: prNumber,
+            });
+            
+            const botComment = comments.data.find(comment => 
+              comment.user.type === 'Bot' && 
+              comment.body.includes('🚀 Digger Deployment Status')
+            );
+            
+            const timestamp = new Date().toISOString();
+            const status = jobStatus === 'success' ? '✅' : '❌';
+            const statusText = jobStatus === 'success' ? 'SUCCESS' : 'FAILED';
+            
+            let commentBody = `## 🚀 Digger Deployment Status\n\n`;
+            commentBody += `**Latest Update:** ${timestamp}\n\n`;
+            commentBody += `### Current Deployment\n`;
+            commentBody += `${status} **${action.toUpperCase()}** ${environment.toUpperCase()} - ${statusText}\n`;
+            commentBody += `🔗 [View logs](${runUrl})\n\n`;
+            commentBody += `### Commands\n`;
+            commentBody += `- \`/digger plan\` - Plan all environments\n`;
+            commentBody += `- \`/digger apply dev\` - Deploy to dev environment\n`;
+            commentBody += `- \`/digger apply staging\` - Deploy to staging environment\n`;
+            commentBody += `\n*🔒 Production is read-only (plans only)*\n\n`;
+            commentBody += `---\n*🤖 This comment is automatically updated by Digger CI*`;
+            
+            if (botComment) {
+              // Update existing comment
+              await github.rest.issues.updateComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                comment_id: botComment.id,
+                body: commentBody
+              });
+            } else {
+              // Create new comment
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: prNumber,
+                body: commentBody
+              });
+            }
 
   generate-report:
     needs: detect-environments

--- a/infra/live/dev/us-east-2/network/terragrunt.hcl
+++ b/infra/live/dev/us-east-2/network/terragrunt.hcl
@@ -3,6 +3,7 @@ terraform { source = "../../../../modules/network" }
 inputs = {
   # Basic VPC configuration for dev environment testing
   # Updated to test digger apply dev command
+  # Testing digger comment functionality after merge
   vpc = {
     cidr_block = "10.0.0.0/16"
     tags = {


### PR DESCRIPTION
Test PR to validate that `/digger plan` and `/digger apply dev` commands work correctly now that the workflow is on main branch.

## Testing Plan
1. First test `/digger plan` (safe operation)  
2. If plan works, test `/digger apply dev` 
3. Validate that issue comment events trigger workflows properly

This PR has a minimal change to `infra/live/dev/us-east-2/network/terragrunt.hcl` to trigger environment detection.