### PR TITLE
feat: Add CloudWatch logging infrastructure and enable real portal data

### DIFF
--- a/infra/live/dev/us-east-2/cloudwatch/terragrunt.hcl
+++ b/infra/live/dev/us-east-2/cloudwatch/terragrunt.hcl
@@ -1,0 +1,35 @@
+include "root" { path = find_in_parent_folders() }
+terraform { source = "../../../../modules/cloudwatch" }
+inputs = {
+  environment = "dev"
+  log_groups = {
+    "/aws/lambda/dev-functions" = {
+      retention_days = 14
+      tags = {
+        Purpose     = "Lambda function logs for dev environment"
+        Environment = "dev"
+      }
+    }
+    "/aws/apigateway/dev-apis" = {
+      retention_days = 14
+      tags = {
+        Purpose     = "API Gateway execution logs for dev environment" 
+        Environment = "dev"
+      }
+    }
+    "/brainsway/infrastructure/dev" = {
+      retention_days = 30
+      tags = {
+        Purpose     = "Infrastructure deployment and application logs for dev"
+        Environment = "dev"
+      }
+    }
+    "/brainsway/ec2/dev" = {
+      retention_days = 7
+      tags = {
+        Purpose     = "EC2 instance logs for dev environment"
+        Environment = "dev"
+      }
+    }
+  }
+}

--- a/infra/live/staging/us-east-2/cloudwatch/terragrunt.hcl
+++ b/infra/live/staging/us-east-2/cloudwatch/terragrunt.hcl
@@ -1,0 +1,42 @@
+include "root" { path = find_in_parent_folders() }
+terraform { source = "../../../../modules/cloudwatch" }
+inputs = {
+  environment = "staging"
+  log_groups = {
+    "/aws/lambda/staging-functions" = {
+      retention_days = 30
+      tags = {
+        Purpose     = "Lambda function logs for staging environment"
+        Environment = "staging"
+      }
+    }
+    "/aws/apigateway/staging-apis" = {
+      retention_days = 30
+      tags = {
+        Purpose     = "API Gateway execution logs for staging environment"
+        Environment = "staging"
+      }
+    }
+    "/brainsway/infrastructure/staging" = {
+      retention_days = 60
+      tags = {
+        Purpose     = "Infrastructure deployment and application logs for staging"
+        Environment = "staging"
+      }
+    }
+    "/brainsway/ec2/staging" = {
+      retention_days = 14
+      tags = {
+        Purpose     = "EC2 instance logs for staging environment"
+        Environment = "staging"
+      }
+    }
+    "/brainsway/rds/staging" = {
+      retention_days = 30
+      tags = {
+        Purpose     = "RDS and Aurora database logs for staging"
+        Environment = "staging"
+      }
+    }
+  }
+}

--- a/infra/modules/cloudwatch/main.tf
+++ b/infra/modules/cloudwatch/main.tf
@@ -1,0 +1,38 @@
+terraform {
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = ">= 5.0"
+    }
+  }
+}
+
+resource "aws_cloudwatch_log_group" "this" {
+  for_each          = var.log_groups
+  name              = each.key
+  retention_in_days = try(each.value.retention_days, 30)
+  skip_destroy      = try(each.value.skip_destroy, false)
+  
+  tags = merge(
+    try(each.value.tags, {}),
+    {
+      Name        = each.key
+      Environment = var.environment
+      ManagedBy   = "Terraform"
+    }
+  )
+  
+  lifecycle { 
+    ignore_changes = [tags]
+  }
+}
+
+resource "aws_cloudwatch_log_stream" "this" {
+  for_each = {
+    for k, v in var.log_groups : k => v 
+    if try(v.create_default_stream, true) == true
+  }
+  
+  name           = "${each.key}-default"
+  log_group_name = aws_cloudwatch_log_group.this[each.key].name
+}

--- a/infra/modules/cloudwatch/outputs.tf
+++ b/infra/modules/cloudwatch/outputs.tf
@@ -1,0 +1,18 @@
+output "log_group_names" {
+  value = keys(aws_cloudwatch_log_group.this)
+  description = "List of created log group names"
+}
+
+output "log_group_arns" {
+  value = { 
+    for k, v in aws_cloudwatch_log_group.this : k => v.arn 
+  }
+  description = "Map of log group names to their ARNs"
+}
+
+output "log_streams" {
+  value = {
+    for k, v in aws_cloudwatch_log_stream.this : k => v.name
+  }
+  description = "Map of log group names to their default log stream names"
+}

--- a/infra/modules/cloudwatch/variables.tf
+++ b/infra/modules/cloudwatch/variables.tf
@@ -1,0 +1,16 @@
+variable "environment" {
+  type        = string
+  description = "Environment name (dev, staging, prod)"
+}
+
+variable "log_groups" {
+  # key = log group name  
+  type = map(object({
+    retention_days       = optional(number, 30)
+    skip_destroy         = optional(bool, false)
+    create_default_stream = optional(bool, true)
+    tags                 = optional(map(string), {})
+  }))
+  description = "Map of CloudWatch Log Groups to create"
+  default     = {}
+}


### PR DESCRIPTION
## Summary

This PR adds cost-free CloudWatch logging infrastructure to dev and staging environments and enables the infrastructure portal to display real deployment reports instead of mock data.

## Infrastructure Changes

### 🆕 New CloudWatch Module
- **Module**: `infra/modules/cloudwatch/`
- **Purpose**: Centralized logging for AWS services
- **Cost**: Free tier (5GB ingestion + 5GB storage per month)

### 📋 Log Groups Added
**Dev Environment:**
- `/aws/lambda/dev-functions` (14 day retention)
- `/aws/apigateway/dev-apis` (14 day retention) 
- `/brainsway/infrastructure/dev` (30 day retention)
- `/brainsway/ec2/dev` (7 day retention)

**Staging Environment:**
- `/aws/lambda/staging-functions` (30 day retention)
- `/aws/apigateway/staging-apis` (30 day retention)
- `/brainsway/infrastructure/staging` (60 day retention)
- `/brainsway/ec2/staging` (14 day retention)
- `/brainsway/rds/staging` (30 day retention)

## Portal Improvements

### 🔧 Real Data Integration
- **Removed**: Mock data fallback from portal
- **Fixed**: Portal baseURL to fetch from actual GitHub Pages deployment
- **Enhanced**: Error handling for when no deployment reports exist yet
- **Improved**: User messaging about report generation

### 📊 Expected Workflow
1. **PR Creation** → Triggers Digger workflow
2. **Digger Runs** → Generates deployment reports
3. **Reports Deployed** → Available at portal URLs
4. **Portal Shows** → Real deployment data instead of mock data

## Testing This PR

After creating this PR, you should see:
1. **PR Comment** with link to infrastructure portal
2. **Digger Planning** for dev and staging environments
3. **Portal Reports** generated and accessible
4. **Real Data** in the portal dashboard

## Cost Analysis
- **CloudWatch Log Groups**: /bin/zsh (within free tier limits)
- **GitHub Pages**: /bin/zsh (public repository)
- **Additional AWS Resources**: /bin/zsh (log groups only)

## Security & Compliance
- All log groups properly tagged with environment and purpose
- Appropriate retention periods to balance cost and compliance
- No sensitive data exposure (infrastructure logs only)

---
🎯 **[View Infrastructure Portal](https://mottysisam.github.io/brainsway-infra/)** (will show real data after deployment)